### PR TITLE
Clarify imputation notebook text and tests

### DIFF
--- a/labs/machine-learning/robust-features-8-1/laneguard_8_1.ipynb
+++ b/labs/machine-learning/robust-features-8-1/laneguard_8_1.ipynb
@@ -59,7 +59,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The rows with a missing temperature reading fail at more than four times the rate of rows with a recorded one.\n\n**Predict:** Given that result, what do you think is causing the temperature values to go missing? Write your reasoning in the cell below before continuing."
+    "The rows with a missing temperature reading fail at 4.4 times the rate of rows with a recorded one.\n\n**Predict:** Given that result, what do you think is causing the temperature values to go missing? Write your reasoning in the cell below before continuing."
    ]
   },
   {
@@ -80,7 +80,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The next two cells set up everything needed to compare the three strategies. The first defines the classifier and a helper function that handles training and scoring. The second does the train/test split and computes the fill value. Run both and note the fill value: that is the number that will replace every missing temperature reading in the two imputation strategies."
+    "The three strategies are:\n\n- **Drop** — remove every training row where temperature is missing\n- **Mean imputation** — keep those rows but fill each missing temperature with the column mean\n- **Mean + indicator** — fill with the mean and add a column called `temp_was_missing` that records which rows the sensor tripped on\n\nThe next two cells set up everything needed to run all three. The first defines the classifier and a helper function that handles training and scoring. The second does the train/test split and computes the fill value: that is the number that will replace every missing temperature reading in the two imputation strategies."
    ]
   },
   {
@@ -89,14 +89,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.ensemble import GradientBoostingClassifier\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.metrics import f1_score, recall_score\n\nTARGET = 'failure_within_24h'\nBASE   = ['pinsetter_drive_temp', 'pinsetter_chassis_vibration',\n          'days_since_service', 'cycles_since_service']\n\ndef fit_and_score(X_tr, y_tr, X_te, y_te):\n    # Up-weight failure cases: 9% failure rate means the model will ignore\n    # them without this correction\n    w = np.where(y_tr == 1, (y_tr == 0).sum() / (y_tr == 1).sum(), 1.0)\n    # n_estimators=300 gives stable results: the qualitative ordering\n    # (drop worst, mean+flag best F1) only holds reliably at this setting\n    m = GradientBoostingClassifier(n_estimators=300, learning_rate=0.05,\n                                   max_depth=4, subsample=0.8, random_state=42)\n    m.fit(X_tr, y_tr, sample_weight=w)\n    p = m.predict(X_te)\n    return m, f1_score(y_te, p, zero_division=0), \\\n              recall_score(y_te, p, zero_division=0), p"
+    "from sklearn.ensemble import GradientBoostingClassifier\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.metrics import f1_score, recall_score\n\nTARGET = 'failure_within_24h'\nBASE   = ['pinsetter_drive_temp', 'pinsetter_chassis_vibration',\n          'days_since_service', 'cycles_since_service']\n\ndef fit_and_score(X_tr, y_tr, X_te, y_te):\n    # Up-weight failure cases: 9% failure rate means the model will ignore\n    # them without this correction\n    w = np.where(y_tr == 1, (y_tr == 0).sum() / (y_tr == 1).sum(), 1.0)\n    # n_estimators=300 gives stable results: the ranking of strategies\n    # (drop worst, mean+flag best F1) only holds reliably at this setting\n    m = GradientBoostingClassifier(n_estimators=300, learning_rate=0.05,\n                                   max_depth=4, subsample=0.8, random_state=42)\n    m.fit(X_tr, y_tr, sample_weight=w)\n    p = m.predict(X_te)\n    return m, f1_score(y_te, p, zero_division=0), \\\n              recall_score(y_te, p, zero_division=0), p"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The helper function applies class weighting: with a 9.1% failure rate, an unweighted model would simply predict \"no failure\" for every row and achieve 90% accuracy while catching nothing. The weighting scales up the influence of failure rows during training so the model actually learns to find them. `n_estimators=300` is set deliberately: at lower values the qualitative ordering between strategies can shift."
+    "The helper function `fit_and_score` handles one subtlety worth knowing about. The dataset has a 9.1% failure rate, which means roughly 9 failure rows for every 91 normal ones. A classifier that sees that imbalance will often take the path of least resistance: predict \"no failure\" for every single row and be right 91% of the time. It never actually learns what failure looks like.\n\nThe `sample_weight` argument corrects for this by telling the model to treat each failure row as if it appeared roughly ten times in training. The model can no longer ignore failures: each one costs too much in the optimisation for the model to simply predict zero for everything. This is standard practice with imbalanced classification problems and is not specific to this dataset.\n\n`n_estimators=300` is set deliberately: at lower values the qualitative ordering between strategies can shift."
    ]
   },
   {
@@ -105,7 +105,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Split before cleaning: all three strategies must face the same test rows\nidx_tr, idx_te = train_test_split(\n    df.index, test_size=0.2, random_state=42, stratify=df[TARGET])\ntrain, test = df.loc[idx_tr].copy(), df.loc[idx_te].copy()\n\n# Fill value from training data only, never from test rows\nfill = train['pinsetter_drive_temp'].mean()\nprint(f\"Fill value: {fill:.1f} degrees C  |  Test failures: {test[TARGET].sum()}\")"
+    "# Split before cleaning: all three strategies must face the same test rows\n# stratify keeps the same failure rate in train and test as in the full dataset\nidx_tr, idx_te = train_test_split(\n    df.index, test_size=0.2, random_state=42, stratify=df[TARGET])\ntrain, test = df.loc[idx_tr].copy(), df.loc[idx_te].copy()\n\n# Fill value from training data only, never from test rows\nfill = train['pinsetter_drive_temp'].mean()\nprint(f\"Fill value: {fill:.1f} degrees C  |  Test failures: {test[TARGET].sum()}\")"
    ]
   },
   {
@@ -204,7 +204,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Mean imputation caught 17 failures. Drop caught 9.\n\nCheck your prediction from above: did you expect mean imputation to outperform drop? Most people expect drop to be safe and mean to introduce error. The result is the opposite, and the reason is fact 3: the rows the drop strategy removed contained approximately a third of all failure cases in the dataset. Mean imputation kept those rows. The temperature signal in them was wrong, 66 degrees instead of whatever extreme value preceded failure, but the other features still carried enough signal for the model to find some of those failures anyway.\n\nThe third strategy does the same fill but adds one more column. Before overwriting the temperature, it records which rows had a missing value by setting a new column called `temp_was_missing` to 1 for those rows and 0 for everything else. The model then has four features about the machine's physical state, plus a fifth that marks exactly the rows where the sensor tripped. Those rows have a failure rate of around 33%. The model can learn from that pattern directly, independently of whatever imputed temperature value sits alongside it.\n\n**Predict:** Given that the indicator column marks the exact rows with the highest failure rate, do you expect recall to improve, stay the same, or get worse compared to mean imputation alone? Write your reasoning in the cell below before running."
+    "Mean imputation caught 17 failures. Drop caught 9.\n\nCheck your prediction from above: did you expect mean imputation to outperform drop? Most people expect drop to be safe and mean to introduce error. The result is the opposite, and the reason is fact 3: the rows the drop strategy removed contained approximately a third of all failure cases in the dataset. Mean imputation kept those rows. The temperature signal in them was wrong, 66 degrees instead of whatever extreme value preceded failure, but the other features still carried enough signal for the model to find some of those failures anyway.\n\nThe third strategy does the same fill but adds one more column. Before overwriting the temperature, it records which rows had a missing value by setting a new column called `temp_was_missing` to 1 for those rows and 0 for everything else. The model then has four features about the machine's physical state, plus a fifth that marks exactly the rows where the sensor tripped. Those rows have a failure rate of around 30%, more than four times the rate of rows with a recorded temperature. The model can learn from that pattern directly, independently of whatever imputed temperature value sits alongside it.\n\n**Predict:** Given that the indicator column marks the exact rows with the highest failure rate, do you expect recall to improve, stay the same, or get worse compared to mean imputation alone? Write your reasoning in the cell below before running."
    ]
   },
   {
@@ -243,7 +243,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Mean and mean + indicator caught the same number of failures: 17 out of 55. The recall is identical. But the F1 is slightly higher for mean + indicator, which means it made fewer false alarms while catching the same failures.\n\nThe same recall does not mean the two models learned the same thing. In Workshop 7 you used SHAP to understand what a model learned: SHAP gives a per-prediction score for each feature, showing how much it pushed the output up or down for that specific row. SHAP is the right tool for this comparison, but it requires a C extension that is not available in this JupyterLite environment. The cell below uses scikit-learn's built-in `feature_importances_` instead. This gives a global view across the whole model rather than per-prediction scores, so it is less precise than SHAP, but it tells the same story here: look at which features each model found useful, and notice what appears in one plot that does not appear in the other."
+    "Mean and mean + indicator caught the same number of failures: 17 out of 55. The recall is identical. But the F1 is slightly higher for mean + indicator, which means it made fewer false alarms while catching the same failures.\n\nThe same recall does not mean the two models learned the same thing. In Workshop 7 you used SHAP to understand what a model learned: SHAP gives a per-prediction score for each feature, showing how much it pushed the output up or down for that specific row. SHAP is the right tool for this comparison, but it requires a compiled package that is not available in this JupyterLite environment. The cell below uses scikit-learn's built-in `feature_importances_` instead. This gives a global view across the whole model rather than per-prediction scores, so it is less precise than SHAP, but it tells the same story here: look at which features each model found useful, and notice what appears in one plot that does not appear in the other."
    ]
   },
   {
@@ -259,7 +259,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The feature importance plots show what each model relied on most heavily during training.\n\nIn the mean imputation model, temperature is the most important feature. That is technically correct: the model used that column heavily. But roughly 300 of those temperature values were filled in by the cleaning script, not recorded by the sensor. The model does not know which ones. The importance measure cannot tell you either.\n\nIn the mean + indicator model, `temp_was_missing` appears as one of the five features the model learned from. That column contains no temperature data at all, only a 0 or a 1 recording whether a reading was absent. The model has learned that the sensor going silent is itself an event worth paying attention to.\n\n**Reflect:** If you showed the mean imputation model's feature importance chart to the centre's operations manager, they would see \"temperature is the most important factor.\" That statement is accurate. Write in the cell below: in what sense is it also misleading, and what would a more honest explanation say?\n\n*Hint: consider what happened to the temperature values in the rows where the sensor tripped, before the model ever saw them.*"
+    "The feature importance plots show what each model relied on most heavily during training.\n\nIn the mean imputation model, temperature is the most important feature at 0.43, followed by cycles since service at 0.28. That is technically correct: the model used those columns heavily. But roughly 300 of the temperature values were filled in by the cleaning script, not recorded by the sensor. The model does not know which ones. When the temperature signal is partly fictitious, the model partially compensates by leaning more heavily on cycles since service, the next most available signal. The importance measure cannot tell you that is what happened.\n\nIn the mean + indicator model, temperature drops slightly to 0.32, and `temp_was_missing` appears at 0.11. Cycles since service moves up to 0.30, now the joint-top feature alongside temperature. That column contains no temperature data at all, only a 0 or a 1 recording whether a reading was absent. The model has learned that the sensor going silent is itself an event worth acting on, and with that signal available, the weight distribution across all features shifts to reflect what the data actually contains.\n\n**Reflect:** If you showed the mean imputation model's feature importance chart to the centre's operations manager, they would see \"temperature is the most important factor.\" That statement is accurate. Write in the cell below: in what sense is it also misleading, and what would a more honest explanation say?\n\n*Hint: consider what happened to the temperature values in the rows where the sensor tripped, before the model ever saw them.*"
    ]
   },
   {
@@ -289,7 +289,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Read the class definition carefully before running the tests below."
+    "Read the class definition carefully. The tests are in Cell 43, a few cells down."
    ]
   },
   {
@@ -335,7 +335,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The validator currently stops the pipeline completely when a null temperature arrives. That is useful during development, but in production you may want to let the row through while still flagging it, passing it to the mean + indicator path rather than rejecting it outright.\n\n**Challenge:** Copy the `LaneReading` class from above into the cell below and rename it `LaneReadingV2`. Then make two changes:\n\n1. Remove the `flag_non_random_null` field validator entirely.\n2. Add a new field `temp_was_missing: bool = False` to the class.\n\nThen modify `convert_nan_to_none` so that after converting NaN values to None, it also sets `temp_was_missing` to `True` if `pinsetter_drive_temp` is None. That is one extra line inside the existing method.\n\nEvery row should pass validation. A row with a missing temperature should come out with `temp_was_missing=True`. A complete row should come out with `temp_was_missing=False`. No code outside the class should be needed."
+    "The validator currently stops the pipeline completely when a null temperature arrives. That is useful during development, but in production you may want to let the row through while still flagging it, passing it to the mean + indicator path rather than rejecting it outright.\n\n**Challenge:** Copy the `LaneReading` class from above into the cell below and rename it `LaneReadingV2`. Then make two changes:\n\n1. Remove the `flag_non_random_null` field validator entirely.\n2. Add a new field `temp_was_missing: bool = False` to the class.\n\nThen modify `convert_nan_to_none` so that after converting NaN values to None, it also sets `temp_was_missing` to `True` if `pinsetter_drive_temp` is None. That is one extra line inside the existing method.\n\nEvery row should pass validation. A row with a missing temperature should come out with `temp_was_missing=True`. A complete row should come out with `temp_was_missing=False`. No code outside the class should be needed.\n\n*Note: the test cell below uses `**null_row` to pass a dictionary as keyword arguments to the class — the `**` unpacks the dict so each key becomes a named argument. This is standard Python and is the same pattern used throughout this notebook when constructing `LaneReading` objects from dataframe rows.*"
    ]
   },
   {
@@ -344,7 +344,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Write your LaneReadingV2 class below\n\n\n# Uncomment to test your solution once written:\n# null_row = df[df['pinsetter_drive_temp'].isnull()].iloc[0].to_dict()\n# r = LaneReadingV2(**null_row)\n# print(f\"temp_was_missing={r.temp_was_missing}\")  # should be True\n# healthy = df.dropna().iloc[0].to_dict()\n# r2 = LaneReadingV2(**healthy)\n# print(f\"temp_was_missing={r2.temp_was_missing}\")  # should be False\n"
+    "# Write your LaneReadingV2 class here\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run this cell to test your solution\nnull_row = df[df['pinsetter_drive_temp'].isnull()].iloc[0].to_dict()\nr = LaneReadingV2(**null_row)\nprint(f\"temp_was_missing={r.temp_was_missing}\")  # should be True\n\nhealthy = df.dropna().iloc[0].to_dict()\nr2 = LaneReadingV2(**healthy)\nprint(f\"temp_was_missing={r2.temp_was_missing}\")  # should be False"
    ]
   },
   {


### PR DESCRIPTION
Improve clarity and instructions in laneguard_8_1.ipynb: update quantitative wording (e.g. missing temp rate to 4.4x), enumerate the three imputation strategies, and tighten comments in the training helper (note about strategy ranking and stratify in train/test split). Replace reference to a C extension with a compiled package for SHAP, add more explicit feature-importance commentary (including example values), and note the location of the test cell. Finally, restructure the LaneReadingV2 challenge by adding a separate runnable test cell and expand the challenge note (including the **null_row explanation) so students can run validation interactively.